### PR TITLE
Add validation to herd parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
 use crate::models::{Herd, Yak};
 use quick_xml::de::from_str;
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
 
@@ -38,12 +39,28 @@ impl From<HerdXml> for Herd {
 }
 
 pub fn parse_herd_xml(file_path: &str) -> Result<Herd, Box<dyn std::error::Error>> {
-    let mut file = File::open(file_path)?;
+    let mut file = File::open(file_path)
+        .map_err(|e| format!("failed to read {}: {}", file_path, e))?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
 
     // trim text nodes to match expected deserialization format
-    let result: HerdXml = from_str(&contents)?;
+    let result: HerdXml = from_str(&contents)
+        .map_err(|e| format!("failed to parse {}: {}", file_path, e))?;
+
+    // Validate all entries before conversion
+    let mut names: HashSet<String> = HashSet::new();
+    for yak in &result.labyaks {
+        if yak.age < 0.0 {
+            return Err(format!("negative age for yak {}", yak.name).into());
+        }
+        if yak.sex != 'm' && yak.sex != 'f' {
+            return Err(format!("invalid sex '{}' for yak {}", yak.sex, yak.name).into());
+        }
+        if !names.insert(yak.name.clone()) {
+            return Err(format!("duplicate yak name: {}", yak.name).into());
+        }
+    }
 
     let herd = Herd::from(result);
 


### PR DESCRIPTION
## Summary
- validate parsed `Labyak` data when reading herd XML
  - check age is non-negative
  - check sex is `m` or `f`
  - enforce unique yak names
- provide context when file IO or parsing fails

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6845ee4faa608324a79b1db150ce2eb0